### PR TITLE
Contract errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='sylph',
     description='A lightweight python test automation library',
 
-    version='0.6.3',
+    version='0.6.4',
     author="John O'Sullivan",
     author_email='johnosull9@hotmail.com',
     url='https://www.linkedin.com/in/johnosull9/',


### PR DESCRIPTION
If content exists, by default it will be considered a contract error if not valid JSON and a dict.
Can be overridden by specifying validate_json=False